### PR TITLE
Adapt the bot to the new channels created after server raid

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
 		"SEND_MESSAGES_IN_THREADS",
 		"START_EMBEDDED_ACTIVITIES"
 	],
-	"points": ["negacy", "enemy"],
+	"points": ["negacy"],
 	"exchangeable_points": ["negacy"],
 	"creator": "mkpanda#4841",
 	"roles": {

--- a/config.json
+++ b/config.json
@@ -71,10 +71,10 @@
 	"points_for_role": 4,
 	"ticket_command": {
 		"category_id": "1061402693052153866",
-		"non_ticket_channels": ["1061648936709918843"]
+		"non_ticket_channels": ["1072404825364504656"]
 	},
 	"raver": {
-		"channel_id": "541718810722435112",
+		"channel_id": "1072401335569371167",
 		"chance": 20,
 		"min_days": 0,
 		"max_days": 30,
@@ -95,7 +95,7 @@
 		}
 	},
 	"channel_ids": {
-		"quackspam": "596644573485465620"
+		"quackspam": "1072399610594742342"
 	},
 	"messages_patterns": {
 		"level_up": "advanced to level"


### PR DESCRIPTION
Since most of the channels were deleted during the raid they had to be recreated, making the old Ids invalid. This fixes the functionality of the bot by putting in the new Ids.